### PR TITLE
Retry status update before setting status to offline.

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -803,7 +803,7 @@ func (gateway *Gateway) geoCheckCracked(conn Conn, session *Session) error {
 		return nil
 	}
 }
-
+}
 func (gateway *Gateway) usernameCheck(session *Session) error {
 	_, err := gateway.rdb.Get(ctx, "username:"+session.username).Result()
 	if err == redis.Nil {

--- a/proxy.go
+++ b/proxy.go
@@ -3,13 +3,6 @@ package infrared
 import (
 	"encoding/json"
 	"fmt"
-	"log"
-	"net"
-	"strconv"
-	"strings"
-	"sync"
-	"time"
-
 	"github.com/haveachin/infrared/protocol"
 	"github.com/haveachin/infrared/protocol/handshaking"
 	"github.com/haveachin/infrared/protocol/login"
@@ -17,6 +10,12 @@ import (
 	"github.com/pires/go-proxyproto"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"log"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 )
 
 var (

--- a/proxy.go
+++ b/proxy.go
@@ -184,11 +184,7 @@ func (proxy *Proxy) handleLoginConnection(conn Conn, session Session) error {
 	if err != nil {
 		return err
 	}
-
-	if Config.Debug {
-		log.Printf("[i] %s with username %s connects through %s", session.connRemoteAddr, session.username, proxy.UID())
-	}
-
+	log.Printf("[i] %s with username %s connects through %s", session.connRemoteAddr, session.username, proxy.UID())
 	playersConnected.With(prometheus.Labels{"host": proxyDomain}).Inc()
 	defer playersConnected.With(prometheus.Labels{"host": proxyDomain}).Dec()
 
@@ -245,10 +241,7 @@ func (proxy *Proxy) handleStatusConnection(conn Conn, session Session) error {
 			proxy.cacheStatusTime = time.Now()
 			proxy.cacheResponse = status.ClientBoundResponse{}
 			return proxy.handleStatusRequest(conn, false)
-
 		}
-
-		
 
 		if proxy.RealIP() {
 			hs.UpgradeToRealIP(session.connRemoteAddr, time.Now())
@@ -301,7 +294,6 @@ func (proxy *Proxy) handleStatusConnection(conn Conn, session Session) error {
 		proxy.cacheResponse = clientboundResponse
 
 		rconn.Close()
-
 	}
 
 	if !proxy.cacheOnlineStatus {

--- a/proxy.go
+++ b/proxy.go
@@ -155,6 +155,7 @@ func (proxy *Proxy) handleLoginConnection(conn Conn, session Session) error {
 		return proxy.handleLoginRequest(conn, session)
 	}
 	proxy.cacheOnlineStatus = true
+	proxy.cacheOnlineTime = time.Now()
 	defer rconn.Close()
 
 	if proxy.ProxyProtocol() {

--- a/proxy.go
+++ b/proxy.go
@@ -237,7 +237,6 @@ func (proxy *Proxy) handleStatusConnection(conn Conn, session Session) error {
 			}
 
 			log.Printf("[i] Failed to update cache for %s, %s did not respond: %s", proxyUID, proxyTo, err)
-
 			proxy.cacheOnlineStatus = false
 			proxy.cacheStatusTime = time.Now()
 			proxy.cacheResponse = status.ClientBoundResponse{}

--- a/proxy.go
+++ b/proxy.go
@@ -232,11 +232,12 @@ func (proxy *Proxy) handleStatusConnection(conn Conn, session Session) error {
 		if err != nil {
 
 			if !proxy.cacheStatusTime.IsZero() || time.Now().Sub(proxy.cacheStatusTime) < 30*time.Second {
-				log.Printf("[i] Failed to update cache for %s, %s retry updating after 10 sec.", proxyUID, proxyTo)
+				log.Printf("[i] Failed to update cache for %s, %s retry to update in 10 seconds before setting offline status.", proxyUID, proxyTo)
 				return proxy.handleStatusRequest(conn, true)
 			}
 
-			log.Printf("[i] Failed to update cache for %s, %s did not respond to ping for 30 seconds. Status set to offline.", proxyUID, proxyTo)
+			log.Printf("[i] Failed to update cache for %s, %s did not respond: %s", proxyUID, proxyTo, err)
+
 			proxy.cacheOnlineStatus = false
 			proxy.cacheStatusTime = time.Now()
 			proxy.cacheResponse = status.ClientBoundResponse{}

--- a/proxy.go
+++ b/proxy.go
@@ -301,7 +301,6 @@ func (proxy *Proxy) handleStatusConnection(conn Conn, session Session) error {
 		proxy.cacheResponse = clientboundResponse
 
 		rconn.Close()
-		proxy.mu.Unlock()
 
 	}
 


### PR DESCRIPTION
Sometimes server status requests disapear in the aether, thus setting servers to offline status frequently without any real reason. These changes are aim to prevent that from happening.