### PR TITLE
Added support for connection address in metrics

### DIFF
--- a/gateway.go
+++ b/gateway.go
@@ -220,7 +220,9 @@ func (gateway *Gateway) CloseProxy(proxyUID string) {
 		gateway.Proxies.Delete(uid)
 	}
 
-	playersConnected.DeleteLabelValues(proxy.DomainName())
+	for i := range proxy.DomainNames() {
+		playersConnected.DeleteLabelValues(proxy.DomainName(), proxy.DomainNames()[i])
+	}
 
 	closeListener := true
 	gateway.Proxies.Range(func(k, v interface{}) bool {
@@ -263,7 +265,9 @@ func (gateway *Gateway) RegisterProxy(proxy *Proxy) error {
 		}
 	}
 
-	playersConnected.WithLabelValues(proxy.DomainName())
+	for i := range proxy.DomainNames() {
+		playersConnected.WithLabelValues(proxy.DomainName(), proxy.DomainNames()[i])
+	}
 
 	if Config.TrackBandwidth {
 		usedBandwith.WithLabelValues(proxy.DomainName())

--- a/proxy.go
+++ b/proxy.go
@@ -22,7 +22,7 @@ var (
 	playersConnected = promauto.NewGaugeVec(prometheus.GaugeOpts{
 		Name: "infrared_connected",
 		Help: "The total number of connected players",
-	}, []string{"host"})
+	}, []string{"proxy", "host"})
 )
 
 func proxyUID(domain, addr string) string {
@@ -184,9 +184,9 @@ func (proxy *Proxy) handleLoginConnection(conn Conn, session Session) error {
 	if err != nil {
 		return err
 	}
-	log.Printf("[i] %s with username %s connects through %s", session.connRemoteAddr, session.username, proxy.UID())
-	playersConnected.With(prometheus.Labels{"host": proxyDomain}).Inc()
-	defer playersConnected.With(prometheus.Labels{"host": proxyDomain}).Dec()
+	log.Printf("[i] %s with username %s connects through proxy %s (host: %s@%s)", session.connRemoteAddr, session.username, proxy.UID(), session.serverAddress, proxy.ListenTo())
+	playersConnected.With(prometheus.Labels{"proxy": proxyDomain, "host": session.serverAddress}).Inc()
+	defer playersConnected.With(prometheus.Labels{"proxy": proxyDomain, "host": session.serverAddress}).Dec()
 
 	go pipe(rconn, conn, proxy)
 	pipe(conn, rconn, proxy)


### PR DESCRIPTION
When using Infrared proxies, we concluded that it would be useful to find out the exact addresses that players use to connect. This is a useful feature that is not difficult to implement. It allows us to find out how many players are on each of the available proxy domains.